### PR TITLE
Add maven-compiler-plugin to pom.xml, in order to have out of the box…

### DIFF
--- a/code/pom.xml
+++ b/code/pom.xml
@@ -23,6 +23,18 @@
     <name>metaphor</name>
 	<description>A parser for MathType's MTEF binary format</description>
     <url>http://maven.apache.org</url>
+     <build>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.3</version>
+          <configuration>
+            <source>1.6</source>
+            <target>1.6</target>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -48,19 +60,19 @@
             <artifactId>jcl-over-slf4j</artifactId>
             <version>1.6.2</version>
         </dependency>
-        
+
         <dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 			<version>1.2</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>net.sf.saxon</groupId>
 			<artifactId>saxon</artifactId>
 			<version>8.7</version>
 		</dependency>
-            
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
… 'mvn install' working.

Before this addition I could not get `mvn install` to work, because I was getting these errors:

```
[ERROR] /vagrant/code/src/main/java/uk/co/danielrendall/metaphor/records/CHAR.java:[35,22] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR] (use -source 5 or higher to enable generics)
[ERROR] /vagrant/code/src/main/java/uk/co/danielrendall/metaphor/records/CHAR.java:[46,5] error: annotations are not supported in -source 1.3
```
